### PR TITLE
removed deprecated loaders from webpack config.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,18 +31,11 @@ module.exports = {
       },
       {
         test: /\.(png|jpe?g|gif|svg)$/i,
-        use: ['file-loader']
+        type: 'asset'
       },
       {
         test: /\.(mov|mp4)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              name: '[name].[ext]'
-            }  
-          }
-        ]
+        type: 'asset'
       },    
     ],
   }, 


### PR DESCRIPTION
file-loader is no longer supported, and it was breaking some of the image files.